### PR TITLE
Intersect all ranges in and chains

### DIFF
--- a/lib/hex_solver.ex
+++ b/lib/hex_solver.ex
@@ -78,6 +78,9 @@ defmodule HexSolver do
   @doc """
   Parses or converts a SemVer version or Elixir version requirement to an internal solver constraint
   that can be returned by the `HexSolver.Registry` or passed to `HexSolver.run/4`.
+
+  Raises `Version.InvalidRequirementError` if the requirement is invalid and
+  `HexSolver.UnsatisfiableRequirementError` if no version can satisfy it.
   """
   @spec parse_constraint!(String.t() | Version.t() | Version.Requirement.t()) :: constraint()
   def parse_constraint!(string) do

--- a/lib/hex_solver/constraints/range.ex
+++ b/lib/hex_solver/constraints/range.ex
@@ -49,7 +49,7 @@ defmodule HexSolver.Constraints.Range do
     Enum.all?(ranges, &allows_all?(range, &1))
   end
 
-  def allows_any?(%Range{}, %Empty{}), do: true
+  def allows_any?(%Range{}, %Empty{}), do: false
   def allows_any?(%Range{} = range, %Elixir.Version{} = version), do: allows?(range, version)
 
   def allows_any?(%Range{} = left, %Range{} = right) do

--- a/lib/hex_solver/constraints/union.ex
+++ b/lib/hex_solver/constraints/union.ex
@@ -44,7 +44,7 @@ defmodule HexSolver.Constraints.Union do
   defp do_allows_all?(_lefts, []), do: true
   defp do_allows_all?([], _rights), do: false
 
-  def allows_any?(%Union{}, %Empty{}), do: true
+  def allows_any?(%Union{}, %Empty{}), do: false
 
   def allows_any?(%Union{} = left, right) do
     do_allows_any?(to_ranges(left), to_ranges(right))

--- a/lib/hex_solver/constraints/version.ex
+++ b/lib/hex_solver/constraints/version.ex
@@ -14,7 +14,7 @@ defmodule HexSolver.Constraints.Version do
 
   def allows?(%Version{} = left, %Version{} = right), do: left == right
 
-  def allows_any?(%Version{}, %Empty{}), do: true
+  def allows_any?(%Version{}, %Empty{}), do: false
   def allows_any?(%Version{} = left, right), do: Constraint.allows?(right, left)
 
   def allows_all?(%Version{}, %Empty{}) do

--- a/lib/hex_solver/requirement.ex
+++ b/lib/hex_solver/requirement.ex
@@ -1,10 +1,9 @@
 defmodule HexSolver.Requirement do
   @moduledoc false
 
+  alias HexSolver.{Constraint, UnsatisfiableRequirementError}
   alias HexSolver.Constraints.{Empty, Range, Util}
   alias HexSolver.Requirement.Parser
-
-  @allowed_range_ops [:>, :>=, :<, :<=, :~>]
 
   def to_constraint(string) when is_binary(string) do
     case Parser.parse(string) do
@@ -12,7 +11,7 @@ defmodule HexSolver.Requirement do
       :error -> :error
     end
   catch
-    {__MODULE__, :invalid_constraint} ->
+    {__MODULE__, :unsatisfiable, _left, _right} ->
       :error
   end
 
@@ -30,8 +29,8 @@ defmodule HexSolver.Requirement do
       :error -> raise Elixir.Version.InvalidRequirementError, string
     end
   catch
-    {__MODULE__, :invalid_constraint} ->
-      raise Elixir.Version.InvalidRequirementError, string
+    {__MODULE__, :unsatisfiable, left, right} ->
+      raise UnsatisfiableRequirementError, requirement: string, left: left, right: right
   end
 
   def to_constraint!(%Elixir.Version{} = version) do
@@ -52,14 +51,32 @@ defmodule HexSolver.Requirement do
     delex(rest, acc)
   end
 
-  defp delex([op1, version1, op, op2, version2 | rest], acc) when op in [:&&, :and] do
-    range = to_range(op1, version1, op2, version2)
-    delex(rest, [range | acc])
+  defp delex(lexed, acc) do
+    {constraints, rest} = take_intersection(lexed, [])
+    delex(rest, [intersect(constraints) | acc])
   end
 
-  defp delex([op, version | rest], acc) do
-    range = to_range(op, version)
-    delex(rest, [range | acc])
+  defp take_intersection([op, version, and_op | rest], acc) when and_op in [:&&, :and] do
+    take_intersection(rest, [to_range(op, version) | acc])
+  end
+
+  defp take_intersection([op, version | rest], acc) do
+    {Enum.reverse([to_range(op, version) | acc]), rest}
+  end
+
+  defp intersect([constraint | constraints]) do
+    Enum.reduce(constraints, constraint, fn constraint, intersection ->
+      case Constraint.intersect(intersection, constraint) do
+        %Empty{} ->
+          throw(
+            {__MODULE__, :unsatisfiable, Constraint.to_requirement(intersection),
+             Constraint.to_requirement(constraint)}
+          )
+
+        intersection ->
+          intersection
+      end
+    end)
   end
 
   defp to_range(:==, version) do
@@ -96,51 +113,6 @@ defmodule HexSolver.Requirement do
 
   defp to_range(:<=, version) do
     %Range{max: to_version(version), include_max: true}
-  end
-
-  defp to_range(:~>, _version1, :~>, _version2) do
-    throw({__MODULE__, :invalid_constraint})
-  end
-
-  defp to_range(op1, version1, :~>, version2) do
-    to_range(:~>, version2, op1, version1)
-  end
-
-  defp to_range(:~>, version1, op2, version2) do
-    range1 = to_range(:~>, version1)
-    range2 = to_range(op2, version2)
-
-    range = Range.intersect(range1, range2)
-
-    unless Range.valid?(range) and Range.allows_any?(range1, range2) do
-      throw({__MODULE__, :invalid_constraint})
-    end
-
-    range
-  end
-
-  defp to_range(op1, version1, op2, version2)
-       when op1 in @allowed_range_ops and op2 in @allowed_range_ops do
-    range =
-      Map.merge(to_range(op1, version1), to_range(op2, version2), fn
-        :__struct__, Range, Range -> Range
-        :min, nil, value -> value
-        :min, value, nil -> value
-        :max, nil, value -> value
-        :max, value, nil -> value
-        :include_min, value, value -> value
-        :include_min, false, value -> value
-        :include_min, value, false -> value
-        :include_max, value, value -> value
-        :include_max, false, value -> value
-        :include_max, value, false -> value
-      end)
-
-    unless Range.valid?(range) do
-      throw({__MODULE__, :invalid_constraint})
-    end
-
-    range
   end
 
   defp to_version({major, minor, patch, pre, _build}),

--- a/lib/hex_solver/unsatisfiable_requirement_error.ex
+++ b/lib/hex_solver/unsatisfiable_requirement_error.ex
@@ -1,0 +1,14 @@
+defmodule HexSolver.UnsatisfiableRequirementError do
+  @moduledoc """
+  Raised when a version requirement is valid but no version can satisfy it
+  because two of its intersected ranges are disjoint.
+  """
+
+  defexception [:requirement, :left, :right]
+
+  @impl true
+  def message(%__MODULE__{requirement: requirement, left: left, right: right}) do
+    "requirement #{inspect(requirement)} is unsatisfiable because " <>
+      "#{inspect(left)} and #{inspect(right)} are disjoint"
+  end
+end

--- a/test/hex_solver/constraints/range_test.exs
+++ b/test/hex_solver/constraints/range_test.exs
@@ -156,7 +156,7 @@ defmodule HexSolver.Constraints.RangeTest do
   describe "allows_any?/2" do
     property "with empty" do
       check all range <- range() do
-        assert Range.allows_any?(range, %Empty{})
+        refute Range.allows_any?(range, %Empty{})
       end
     end
 

--- a/test/hex_solver/constraints/version_test.exs
+++ b/test/hex_solver/constraints/version_test.exs
@@ -24,6 +24,12 @@ defmodule HexSolver.Constraints.VersionTest do
     end
   end
 
+  property "allows_any?/2 with empty" do
+    check all version <- version() do
+      refute Version.allows_any?(version, %Empty{})
+    end
+  end
+
   property "allows_any?/2" do
     check all version <- version(),
               constraint <- constraint() do

--- a/test/hex_solver/requirement_test.exs
+++ b/test/hex_solver/requirement_test.exs
@@ -2,8 +2,14 @@ defmodule HexSolver.RequirementTest do
   use HexSolver.Case, async: true
   use ExUnitProperties
 
-  alias HexSolver.Requirement
+  alias HexSolver.{Constraint, Requirement, UnsatisfiableRequirementError}
   alias HexSolver.Constraints.{Empty, Range, Union}
+
+  @versions (for major <- 0..2, minor <- 0..2, patch <- 0..2, pre <- ["", "-0", "-rc.1"] do
+               Version.parse!("#{major}.#{minor}.#{patch}#{pre}")
+             end)
+
+  @operators [">", ">=", "<", "<=", "==", "~>"]
 
   describe "to_constraint!/" do
     property "always converts" do
@@ -29,9 +35,17 @@ defmodule HexSolver.RequirementTest do
     end
 
     test "intersect ranges" do
-      assert_raise Version.InvalidRequirementError, fn ->
-        Requirement.to_constraint!("~> 1.0 and ~> 1.1")
-      end
+      assert Requirement.to_constraint!("~> 1.0 and ~> 1.1") == %Range{
+               min: v("1.1.0"),
+               max: v("2.0.0-0"),
+               include_min: true
+             }
+
+      assert Requirement.to_constraint!("~> 1.0.0 and ~> 1.0") == %Range{
+               min: v("1.0.0"),
+               max: v("1.1.0-0"),
+               include_min: true
+             }
 
       assert Requirement.to_constraint!("~> 1.11 and >= 1.11.6") == %Range{
                min: v("1.11.6"),
@@ -39,8 +53,83 @@ defmodule HexSolver.RequirementTest do
                include_min: true
              }
 
-      assert_raise Version.InvalidRequirementError, fn ->
-        Requirement.to_constraint!("< 0.0.0-0 and >= 1.0.0")
+      assert Requirement.to_constraint!(">= 1.11.6 and ~> 1.11") == %Range{
+               min: v("1.11.6"),
+               max: v("2.0.0-0"),
+               include_min: true
+             }
+
+      assert Requirement.to_constraint!(">= 1.0.0 and > 1.5.0") == %Range{min: v("1.5.0")}
+      assert Requirement.to_constraint!("< 2.0.0 and <= 3.0.0") == %Range{max: v("2.0.0")}
+      assert Requirement.to_constraint!("~> 1.0 and <= 1.0.0") == v("1.0.0")
+      assert Requirement.to_constraint!("== 1.0.0 and >= 1.0.0") == v("1.0.0")
+      assert Requirement.to_constraint!(">= 1.0.0 and <= 1.0.0") == v("1.0.0")
+
+      for {requirement, left, right} <- [
+            {"~> 1.0 and ~> 2.0", "~> 1.0", "~> 2.0"},
+            {"~> 1.0 and >= 2.0.0", "~> 1.0", ">= 2.0.0"},
+            {"== 1.0.0 and > 1.0.0", "1.0.0", "> 1.0.0"},
+            {"> 1.0.0 and <= 1.0.0", "> 1.0.0", "<= 1.0.0"},
+            {"< 0.0.0-0 and >= 1.0.0", "< 0.0.0-0", ">= 1.0.0"}
+          ] do
+        message =
+          "requirement #{inspect(requirement)} is unsatisfiable because " <>
+            "#{inspect(left)} and #{inspect(right)} are disjoint"
+
+        assert_raise UnsatisfiableRequirementError, message, fn ->
+          Requirement.to_constraint!(requirement)
+        end
+
+        assert Requirement.to_constraint(requirement) == :error
+      end
+    end
+
+    test "intersect more than two ranges" do
+      assert Requirement.to_constraint!(">= 1.0.0 and < 2.0.0 and > 1.5.0") == %Range{
+               min: v("1.5.0"),
+               max: v("2.0.0")
+             }
+
+      assert Requirement.to_constraint!("~> 1.0 and >= 1.2.0 and < 1.8.0 and >= 1.3.0") ==
+               %Range{min: v("1.3.0"), max: v("1.8.0"), include_min: true}
+
+      union = %Union{
+        ranges: [
+          %Range{min: v("1.5.0"), max: v("2.0.0")},
+          %Range{min: v("3.0.0"), max: v("4.0.0-0"), include_min: true}
+        ]
+      }
+
+      assert Requirement.to_constraint!(">= 1.0.0 and < 2.0.0 and > 1.5.0 or ~> 3.0") == union
+      assert Requirement.to_constraint!("~> 3.0 or >= 1.0.0 and < 2.0.0 and > 1.5.0") == union
+
+      message =
+        ~s(requirement ">= 1.0.0 and < 2.0.0 and >= 2.0.0" is unsatisfiable because ) <>
+          ~s(">= 1.0.0 and < 2.0.0" and ">= 2.0.0" are disjoint)
+
+      assert_raise UnsatisfiableRequirementError, message, fn ->
+        Requirement.to_constraint!(">= 1.0.0 and < 2.0.0 and >= 2.0.0")
+      end
+    end
+
+    property "matches Version.match?/2" do
+      check all terms <- list_of(requirement_term(), min_length: 1, max_length: 4) do
+        requirement = Enum.join(terms, " and ")
+        assert {:ok, parsed} = Version.parse_requirement(requirement)
+
+        case Requirement.to_constraint(requirement) do
+          {:ok, constraint} ->
+            mismatches =
+              Enum.reject(@versions, fn version ->
+                Constraint.allows?(constraint, version) == Version.match?(version, parsed)
+              end)
+
+            assert mismatches == [], "#{requirement} differs from core on #{inspect(mismatches)}"
+
+          :error ->
+            refute Enum.any?(@versions, &Version.match?(&1, parsed)),
+                   "#{requirement} rejected but matches versions"
+        end
       end
     end
 
@@ -56,6 +145,21 @@ defmodule HexSolver.RequirementTest do
                min: v("1.0.0"),
                include_min: true
              }
+    end
+  end
+
+  defp requirement_term() do
+    gen all operator <- StreamData.member_of(@operators),
+            version <- StreamData.member_of(@versions),
+            short? <- StreamData.boolean() do
+      version =
+        if operator == "~>" and short? do
+          "#{version.major}.#{version.minor}"
+        else
+          to_string(version)
+        end
+
+      "#{operator} #{version}"
     end
   end
 end

--- a/test/hex_solver/solver_test.exs
+++ b/test/hex_solver/solver_test.exs
@@ -123,6 +123,14 @@ defmodule HexSolver.SolverTest do
              }
     end
 
+    test "backtrack from unsatisfiable dependency" do
+      Registry.put("foo", "1.1.0", [{"bar", "< 0.0.0-0"}])
+      Registry.put("foo", "1.0.0", [{"bar", "~> 1.0"}])
+      Registry.put("bar", "1.0.0", [])
+
+      assert run([{"foo", "~> 1.0"}]) == %{"foo" => "1.0.0", "bar" => "1.0.0"}
+    end
+
     test "overlapping ranges" do
       Registry.put("phoenix_live_view", "1.0.0", [{"phoenix", "~> 1.0 or ~> 2.0"}])
       Registry.put("phoenix_live_view", "1.1.0", [{"phoenix", "~> 2.1"}])
@@ -170,6 +178,16 @@ defmodule HexSolver.SolverTest do
       assert term.package_range.name == "foo"
       assert term.package_range.constraint == Version.parse!("1.0.0")
       assert incompatibility.cause == :no_versions
+    end
+
+    test "unsatisfiable dependency" do
+      Registry.put("foo", "1.0.0", [{"bar", "< 0.0.0-0"}])
+      Registry.put("bar", "1.0.0", [])
+
+      assert {:conflict, incompatibility, _} = run([{"foo", "1.0.0"}])
+      assert [term] = incompatibility.terms
+      assert term.package_range.name == "foo"
+      assert {:conflict, %{cause: :dependency}, %{cause: :no_versions}} = incompatibility.cause
     end
 
     test "no matching transient dependency 1" do

--- a/test/hex_solver_test.exs
+++ b/test/hex_solver_test.exs
@@ -46,6 +46,7 @@ defmodule HexSolverTest do
     assert HexSolver.parse_constraint(Version.parse!("1.0.0")) == Version.parse("1.0.0")
 
     assert HexSolver.parse_constraint("1.2.3.4") == :error
+    assert HexSolver.parse_constraint("~> 1.0 and >= 2.0.0") == :error
   end
 
   test "parse_constraint!/1" do
@@ -58,6 +59,10 @@ defmodule HexSolverTest do
            }
 
     assert HexSolver.parse_constraint!(Version.parse!("1.0.0")) == Version.parse!("1.0.0")
+
+    assert_raise HexSolver.UnsatisfiableRequirementError, fn ->
+      HexSolver.parse_constraint!("~> 1.0 and >= 2.0.0")
+    end
 
     assert_raise Version.InvalidRequirementError, fn ->
       HexSolver.parse_constraint!("1.2.3.4")


### PR DESCRIPTION
`HexSolver.Requirement` only handled two-term `and` groups and special-cased their operator combinations, so requirements that `Version.parse_requirement/1` accepts and hexpm lets through on publish either crashed with `FunctionClauseError` (`>= 1.0.0 and < 2.0.0 and > 1.5.0`, `>= 1.0.0 and > 1.5.0`, `== 1.0.0 and >= 1.0.0`, `~> 1.0 and >= 2.0.0`) or were rejected (`~> 1.0.0 and ~> 1.0`). `delex/2` now folds every `and` group through `Constraint.intersect/2`, which replaces all `to_range/4` clauses. Semantics match core: a property checks `Constraint.allows?/2` against `Version.match?/2` for random one to four term chains over a version grid.

An empty intersection raises the new `HexSolver.UnsatisfiableRequirementError`, whose message names the two disjoint parts: `requirement "~> 1.0 and >= 2.0.0" is unsatisfiable because "~> 1.0" and ">= 2.0.0" are disjoint`. `parse_constraint/1` keeps returning `:error`.

The first commit fixes a separate solver bug found while checking what an empty constraint does downstream. When a dependency's constraint is `%Empty{}` (reachable with a published `< 0.0.0-0` requirement since #44) and the depender has another version to backtrack to, `HexSolver.run/4` never returned: `allows_any?/2` returned `true` against an empty constraint, so the no-versions incompatibility related as overlapping and unit propagation derived `not bar empty` indefinitely. The `Range`, `Version` and `Union` clauses now return `false`. `Empty.allows_any?/2` is unchanged on purpose: flipping it too makes the dependency incompatibility conflict with itself and the failure message degrades to `depends on both "bar empty" and "bar empty"`.

Closes #49.
